### PR TITLE
feat(app-users): admin management of mobile users (stages 1-2)

### DIFF
--- a/apps/api/src/db/migrate.ts
+++ b/apps/api/src/db/migrate.ts
@@ -89,14 +89,52 @@ export async function migrateDatabase() {
       executed_at TIMESTAMP
     );
 
+    CREATE TABLE IF NOT EXISTS app_users (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      email VARCHAR(255) NOT NULL UNIQUE,
+      password_hash TEXT,
+      google_id VARCHAR(128),
+      display_name VARCHAR(100),
+      avatar_url TEXT,
+      language VARCHAR(8) NOT NULL DEFAULT 'en',
+      email_verified BOOLEAN NOT NULL DEFAULT false,
+      status VARCHAR(16) NOT NULL DEFAULT 'active',
+      must_change_password BOOLEAN NOT NULL DEFAULT false,
+      blocked_at TIMESTAMP,
+      blocked_reason TEXT,
+      deleted_at TIMESTAMP,
+      purge_at TIMESTAMP,
+      last_login_at TIMESTAMP,
+      created_by UUID REFERENCES users(id),
+      created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+    );
+
+    CREATE TABLE IF NOT EXISTS sso_config (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      provider VARCHAR(30) NOT NULL,
+      enabled BOOLEAN NOT NULL DEFAULT false,
+      client_id TEXT,
+      client_secret TEXT,
+      redirect_uri TEXT,
+      logto_endpoint TEXT,
+      require_email_verification BOOLEAN NOT NULL DEFAULT false,
+      updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+      updated_by UUID REFERENCES users(id)
+    );
+
     -- Indexes (IF NOT EXISTS supported in PG 9.5+)
     CREATE INDEX IF NOT EXISTS idx_devices_group_id ON devices(group_id);
     CREATE INDEX IF NOT EXISTS idx_devices_last_heartbeat ON devices(last_heartbeat);
     CREATE INDEX IF NOT EXISTS idx_devices_user_id ON devices(user_id);
+    CREATE INDEX IF NOT EXISTS idx_devices_app_user_id ON devices(app_user_id);
     CREATE INDEX IF NOT EXISTS idx_devices_location ON devices(lat, lon);
     CREATE INDEX IF NOT EXISTS idx_stats_device_date ON stats(device_id, date);
     CREATE INDEX IF NOT EXISTS idx_sync_group_consumed ON sync_triggers(group_id, consumed);
     CREATE INDEX IF NOT EXISTS idx_commands_device_status ON device_commands(device_id, status);
+    CREATE INDEX IF NOT EXISTS idx_app_users_google_id ON app_users(google_id);
+    CREATE INDEX IF NOT EXISTS idx_app_users_status ON app_users(status);
+    CREATE INDEX IF NOT EXISTS idx_app_users_purge_at ON app_users(purge_at);
   `);
 
   // Add must_change_password column if it doesn't exist (for upgrades)
@@ -118,6 +156,25 @@ export async function migrateDatabase() {
     ALTER TABLE releases ADD COLUMN IF NOT EXISTS auto_update BOOLEAN NOT NULL DEFAULT false;
     ALTER TABLE releases ADD COLUMN IF NOT EXISTS min_version VARCHAR(20);
     ALTER TABLE devices ADD COLUMN IF NOT EXISTS hardware_type VARCHAR(30) DEFAULT 'esp32c3-v1';
+  `);
+
+  // Add app_users profile/lifecycle columns (for upgrades from pre-user-management schema)
+  await db.execute(sql`
+    ALTER TABLE app_users ADD COLUMN IF NOT EXISTS avatar_url TEXT;
+    ALTER TABLE app_users ADD COLUMN IF NOT EXISTS language VARCHAR(8) NOT NULL DEFAULT 'en';
+    ALTER TABLE app_users ADD COLUMN IF NOT EXISTS status VARCHAR(16) NOT NULL DEFAULT 'active';
+    ALTER TABLE app_users ADD COLUMN IF NOT EXISTS must_change_password BOOLEAN NOT NULL DEFAULT false;
+    ALTER TABLE app_users ADD COLUMN IF NOT EXISTS blocked_at TIMESTAMP;
+    ALTER TABLE app_users ADD COLUMN IF NOT EXISTS blocked_reason TEXT;
+    ALTER TABLE app_users ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP;
+    ALTER TABLE app_users ADD COLUMN IF NOT EXISTS purge_at TIMESTAMP;
+    ALTER TABLE app_users ADD COLUMN IF NOT EXISTS last_login_at TIMESTAMP;
+    ALTER TABLE app_users ADD COLUMN IF NOT EXISTS created_by UUID REFERENCES users(id);
+  `);
+
+  // Link devices to app users (for upgrades)
+  await db.execute(sql`
+    ALTER TABLE devices ADD COLUMN IF NOT EXISTS app_user_id UUID REFERENCES app_users(id) ON DELETE SET NULL;
   `);
 
   console.log('[Migrate] Database schema ready.');

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -23,6 +23,7 @@ export const devices = pgTable('devices', {
   deviceId: varchar('device_id', { length: 32 }).notNull().unique(),  // "myathan-XXXXXX"
   apiKey: varchar('api_key', { length: 128 }).notNull(),
   userId: uuid('user_id').references(() => users.id),
+  appUserId: uuid('app_user_id').references(() => appUsers.id, { onDelete: 'set null' }),
   groupId: uuid('group_id').references(() => deviceGroups.id),
   firmwareVersion: varchar('firmware_version', { length: 20 }),
   lastHeartbeat: timestamp('last_heartbeat'),
@@ -39,6 +40,7 @@ export const devices = pgTable('devices', {
   groupIdIdx: index('idx_devices_group_id').on(table.groupId),
   heartbeatIdx: index('idx_devices_last_heartbeat').on(table.lastHeartbeat),
   userIdIdx: index('idx_devices_user_id').on(table.userId),
+  appUserIdIdx: index('idx_devices_app_user_id').on(table.appUserId),
   locationIdx: index('idx_devices_location').on(table.lat, table.lon),
 }));
 
@@ -133,11 +135,23 @@ export const appUsers = pgTable('app_users', {
   passwordHash: text('password_hash'),
   googleId: varchar('google_id', { length: 128 }),
   displayName: varchar('display_name', { length: 100 }),
+  avatarUrl: text('avatar_url'),
+  language: varchar('language', { length: 8 }).notNull().default('en'),
   emailVerified: boolean('email_verified').notNull().default(false),
+  status: varchar('status', { length: 16 }).notNull().default('active'),  // 'active' | 'invited' | 'blocked' | 'deleted'
+  mustChangePassword: boolean('must_change_password').notNull().default(false),
+  blockedAt: timestamp('blocked_at'),
+  blockedReason: text('blocked_reason'),
+  deletedAt: timestamp('deleted_at'),
+  purgeAt: timestamp('purge_at'),
+  lastLoginAt: timestamp('last_login_at'),
+  createdBy: uuid('created_by').references(() => users.id),
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow(),
 }, (table) => ({
   googleIdIdx: index('idx_app_users_google_id').on(table.googleId),
+  statusIdx: index('idx_app_users_status').on(table.status),
+  purgeAtIdx: index('idx_app_users_purge_at').on(table.purgeAt),
 }));
 
 // ─────────────────────────────────────────────────────────────

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,7 @@ import crypto from 'node:crypto';
 import { deviceRoutes } from './routes/device/index.js';
 import { adminRoutes } from './routes/admin/index.js';
 import { analyticsRoutes } from './routes/admin/analytics.js';
+import { appUserAdminRoutes } from './routes/admin/app-users.js';
 import { appAuthRoutes } from './routes/auth/index.js';
 
 // ── Environment validation ──────────────────────────────────
@@ -71,6 +72,7 @@ await app.register(rateLimit, {
 await app.register(deviceRoutes, { prefix: '/api/device' });
 await app.register(adminRoutes, { prefix: '/api/admin' });
 await app.register(analyticsRoutes, { prefix: '/api/admin/analytics' });
+await app.register(appUserAdminRoutes, { prefix: '/api/admin/app-users' });
 await app.register(appAuthRoutes, { prefix: '/api/auth' });
 
 // Health check

--- a/apps/api/src/routes/admin/app-users.ts
+++ b/apps/api/src/routes/admin/app-users.ts
@@ -1,0 +1,425 @@
+import type { FastifyInstance } from 'fastify';
+import { eq, desc, sql, and, isNotNull, or, ilike } from 'drizzle-orm';
+import { z } from 'zod';
+import bcrypt from 'bcryptjs';
+import crypto from 'crypto';
+import rateLimit from '@fastify/rate-limit';
+import { db, schema } from '../../db/index.js';
+import { adminAuth } from '../../middleware/device-auth.js';
+import type { AppUser, AppUserAuthProvider, AppUserStatus } from '@myathan/shared';
+
+const SOFT_DELETE_GRACE_DAYS = 30;
+
+const listQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+  search: z.string().max(255).optional(),
+  status: z.enum(['active', 'invited', 'blocked', 'deleted']).optional(),
+  authProvider: z.enum(['google', 'email']).optional(),
+});
+
+const createSchema = z.object({
+  email: z.string().email().max(255),
+  displayName: z.string().min(1).max(100),
+  tempPassword: z.string().min(8).max(128),
+  language: z.string().min(2).max(8).optional(),
+});
+
+const updateSchema = z.object({
+  email: z.string().email().max(255).optional(),
+  displayName: z.string().min(1).max(100).optional(),
+  language: z.string().min(2).max(8).optional(),
+});
+
+const blockSchema = z.object({
+  reason: z.string().min(1).max(500),
+});
+
+// ── Serializer ──────────────────────────────────────────────
+// Never leak passwordHash or raw googleId. The googleId is replaced
+// by a boolean presence flag via the `authProviders` array.
+function toAppUser(row: typeof schema.appUsers.$inferSelect): AppUser {
+  const providers: AppUserAuthProvider[] = [];
+  if (row.googleId) providers.push('google');
+  if (row.passwordHash) providers.push('email');
+  return {
+    id: row.id,
+    email: row.email,
+    displayName: row.displayName,
+    avatarUrl: row.avatarUrl,
+    language: row.language,
+    status: row.status as AppUserStatus,
+    emailVerified: row.emailVerified,
+    authProviders: providers,
+    mustChangePassword: row.mustChangePassword,
+    lastLoginAt: row.lastLoginAt ? row.lastLoginAt.toISOString() : null,
+    blockedAt: row.blockedAt ? row.blockedAt.toISOString() : null,
+    blockedReason: row.blockedReason,
+    deletedAt: row.deletedAt ? row.deletedAt.toISOString() : null,
+    purgeAt: row.purgeAt ? row.purgeAt.toISOString() : null,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+export async function appUserAdminRoutes(app: FastifyInstance) {
+  await app.register(async function rateLimitedAppUserRoutes(scoped: FastifyInstance) {
+    await scoped.register(rateLimit, { max: 100, timeWindow: '1 minute' });
+
+    // ── GET /api/admin/app-users ────────────────────────────
+    scoped.get('/', {
+      preHandler: adminAuth,
+      config: { rateLimit: { max: 60, timeWindow: '1 minute' } },
+    }, async (request, reply) => {
+      const parsed = listQuerySchema.safeParse(request.query);
+      if (!parsed.success) {
+        return reply.status(400).send({ error: 'Invalid query', details: parsed.error.flatten() });
+      }
+      const { page, limit, search, status, authProvider } = parsed.data;
+      const offset = (page - 1) * limit;
+
+      const conditions = [];
+      if (search) {
+        conditions.push(
+          or(
+            ilike(schema.appUsers.email, `%${search}%`),
+            ilike(schema.appUsers.displayName, `%${search}%`),
+          )
+        );
+      }
+      if (status) {
+        conditions.push(eq(schema.appUsers.status, status));
+      }
+      if (authProvider === 'google') {
+        conditions.push(isNotNull(schema.appUsers.googleId));
+      } else if (authProvider === 'email') {
+        conditions.push(isNotNull(schema.appUsers.passwordHash));
+      }
+
+      const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+      const rows = await db
+        .select()
+        .from(schema.appUsers)
+        .where(whereClause)
+        .orderBy(desc(schema.appUsers.createdAt))
+        .limit(limit)
+        .offset(offset);
+
+      const [{ count }] = await db
+        .select({ count: sql<number>`count(*)` })
+        .from(schema.appUsers)
+        .where(whereClause);
+
+      return reply.send({
+        users: rows.map(toAppUser),
+        total: Number(count),
+        page,
+        limit,
+      });
+    });
+
+    // ── GET /api/admin/app-users/:userId ────────────────────
+    scoped.get<{ Params: { userId: string } }>('/:userId', {
+      preHandler: adminAuth,
+      config: { rateLimit: { max: 60, timeWindow: '1 minute' } },
+    }, async (request, reply) => {
+      const { userId } = request.params;
+
+      const [row] = await db
+        .select()
+        .from(schema.appUsers)
+        .where(eq(schema.appUsers.id, userId))
+        .limit(1);
+
+      if (!row) return reply.status(404).send({ error: 'User not found' });
+
+      const linkedDevices = await db
+        .select({
+          id: schema.devices.id,
+          deviceId: schema.devices.deviceId,
+          firmwareVersion: schema.devices.firmwareVersion,
+          lastHeartbeat: schema.devices.lastHeartbeat,
+          city: schema.devices.city,
+          country: schema.devices.country,
+        })
+        .from(schema.devices)
+        .where(eq(schema.devices.appUserId, userId));
+
+      return reply.send({
+        user: toAppUser(row),
+        devices: linkedDevices,
+      });
+    });
+
+    // ── POST /api/admin/app-users ───────────────────────────
+    // Admin creates a user directly with a temp password.
+    // The temp password is returned ONCE in the response so the
+    // admin can copy it — after this it only exists as a bcrypt hash.
+    scoped.post('/', {
+      preHandler: adminAuth,
+      config: { rateLimit: { max: 20, timeWindow: '1 minute' } },
+    }, async (request, reply) => {
+      const parsed = createSchema.safeParse(request.body);
+      if (!parsed.success) {
+        return reply.status(400).send({ error: 'Invalid input', details: parsed.error.flatten() });
+      }
+      const { email, displayName, tempPassword, language } = parsed.data;
+      const admin = (request as any).user as { id: string };
+
+      const [existing] = await db
+        .select({ id: schema.appUsers.id })
+        .from(schema.appUsers)
+        .where(eq(schema.appUsers.email, email))
+        .limit(1);
+
+      if (existing) {
+        return reply.status(409).send({ error: 'Email already in use' });
+      }
+
+      const passwordHash = await bcrypt.hash(tempPassword, 10);
+
+      const [created] = await db
+        .insert(schema.appUsers)
+        .values({
+          email,
+          passwordHash,
+          displayName,
+          language: language || 'en',
+          status: 'active',
+          mustChangePassword: true,
+          createdBy: admin.id,
+        })
+        .returning();
+
+      return reply.status(201).send({
+        user: toAppUser(created),
+        tempPassword,
+      });
+    });
+
+    // ── PATCH /api/admin/app-users/:userId ──────────────────
+    scoped.patch<{ Params: { userId: string } }>('/:userId', {
+      preHandler: adminAuth,
+      config: { rateLimit: { max: 30, timeWindow: '1 minute' } },
+    }, async (request, reply) => {
+      const parsed = updateSchema.safeParse(request.body);
+      if (!parsed.success) {
+        return reply.status(400).send({ error: 'Invalid input', details: parsed.error.flatten() });
+      }
+      const { userId } = request.params;
+      const { email, displayName, language } = parsed.data;
+
+      // If email is changing, make sure it isn't taken by another user
+      if (email) {
+        const [clash] = await db
+          .select({ id: schema.appUsers.id })
+          .from(schema.appUsers)
+          .where(eq(schema.appUsers.email, email))
+          .limit(1);
+        if (clash && clash.id !== userId) {
+          return reply.status(409).send({ error: 'Email already in use' });
+        }
+      }
+
+      const update: Record<string, unknown> = { updatedAt: new Date() };
+      if (email !== undefined) update.email = email;
+      if (displayName !== undefined) update.displayName = displayName;
+      if (language !== undefined) update.language = language;
+
+      const [updated] = await db
+        .update(schema.appUsers)
+        .set(update)
+        .where(eq(schema.appUsers.id, userId))
+        .returning();
+
+      if (!updated) return reply.status(404).send({ error: 'User not found' });
+      return reply.send({ user: toAppUser(updated) });
+    });
+
+    // ── POST /api/admin/app-users/:userId/block ─────────────
+    scoped.post<{ Params: { userId: string } }>('/:userId/block', {
+      preHandler: adminAuth,
+      config: { rateLimit: { max: 30, timeWindow: '1 minute' } },
+    }, async (request, reply) => {
+      const parsed = blockSchema.safeParse(request.body);
+      if (!parsed.success) {
+        return reply.status(400).send({ error: 'Invalid input', details: parsed.error.flatten() });
+      }
+      const { userId } = request.params;
+      const { reason } = parsed.data;
+
+      const [updated] = await db
+        .update(schema.appUsers)
+        .set({
+          status: 'blocked',
+          blockedAt: new Date(),
+          blockedReason: reason,
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.appUsers.id, userId))
+        .returning();
+
+      if (!updated) return reply.status(404).send({ error: 'User not found' });
+      return reply.send({ user: toAppUser(updated) });
+    });
+
+    // ── POST /api/admin/app-users/:userId/unblock ───────────
+    scoped.post<{ Params: { userId: string } }>('/:userId/unblock', {
+      preHandler: adminAuth,
+      config: { rateLimit: { max: 30, timeWindow: '1 minute' } },
+    }, async (request, reply) => {
+      const { userId } = request.params;
+
+      const [current] = await db
+        .select()
+        .from(schema.appUsers)
+        .where(eq(schema.appUsers.id, userId))
+        .limit(1);
+
+      if (!current) return reply.status(404).send({ error: 'User not found' });
+      if (current.status !== 'blocked') {
+        return reply.status(409).send({ error: 'User is not blocked' });
+      }
+
+      const [updated] = await db
+        .update(schema.appUsers)
+        .set({
+          status: 'active',
+          blockedAt: null,
+          blockedReason: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.appUsers.id, userId))
+        .returning();
+
+      return reply.send({ user: toAppUser(updated) });
+    });
+
+    // ── POST /api/admin/app-users/:userId/reset-password ────
+    // Generates a new temp password, forces change on next login,
+    // and returns it ONCE in the response.
+    scoped.post<{ Params: { userId: string } }>('/:userId/reset-password', {
+      preHandler: adminAuth,
+      config: { rateLimit: { max: 10, timeWindow: '1 minute' } },
+    }, async (request, reply) => {
+      const { userId } = request.params;
+
+      // Generate a 16-char random temp password (alphanumeric, ambiguity-safe)
+      const tempPassword = generateTempPassword(16);
+      const passwordHash = await bcrypt.hash(tempPassword, 10);
+
+      const [updated] = await db
+        .update(schema.appUsers)
+        .set({
+          passwordHash,
+          mustChangePassword: true,
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.appUsers.id, userId))
+        .returning();
+
+      if (!updated) return reply.status(404).send({ error: 'User not found' });
+      return reply.send({ user: toAppUser(updated), tempPassword });
+    });
+
+    // ── DELETE /api/admin/app-users/:userId ─────────────────
+    // Soft delete: mark as deleted and schedule purge after grace period.
+    scoped.delete<{ Params: { userId: string } }>('/:userId', {
+      preHandler: adminAuth,
+      config: { rateLimit: { max: 30, timeWindow: '1 minute' } },
+    }, async (request, reply) => {
+      const { userId } = request.params;
+      const now = new Date();
+      const purgeAt = new Date(now.getTime() + SOFT_DELETE_GRACE_DAYS * 24 * 60 * 60 * 1000);
+
+      const [updated] = await db
+        .update(schema.appUsers)
+        .set({
+          status: 'deleted',
+          deletedAt: now,
+          purgeAt,
+          updatedAt: now,
+        })
+        .where(eq(schema.appUsers.id, userId))
+        .returning();
+
+      if (!updated) return reply.status(404).send({ error: 'User not found' });
+      return reply.send({ user: toAppUser(updated) });
+    });
+
+    // ── POST /api/admin/app-users/:userId/restore ───────────
+    // Undo a soft delete, only valid during the grace window.
+    scoped.post<{ Params: { userId: string } }>('/:userId/restore', {
+      preHandler: adminAuth,
+      config: { rateLimit: { max: 20, timeWindow: '1 minute' } },
+    }, async (request, reply) => {
+      const { userId } = request.params;
+
+      const [current] = await db
+        .select()
+        .from(schema.appUsers)
+        .where(eq(schema.appUsers.id, userId))
+        .limit(1);
+
+      if (!current) return reply.status(404).send({ error: 'User not found' });
+      if (current.status !== 'deleted') {
+        return reply.status(409).send({ error: 'User is not deleted' });
+      }
+      if (current.purgeAt && current.purgeAt <= new Date()) {
+        return reply.status(410).send({ error: 'Grace period expired, user cannot be restored' });
+      }
+
+      const [updated] = await db
+        .update(schema.appUsers)
+        .set({
+          status: 'active',
+          deletedAt: null,
+          purgeAt: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.appUsers.id, userId))
+        .returning();
+
+      return reply.send({ user: toAppUser(updated) });
+    });
+
+    // ── POST /api/admin/app-users/:userId/purge ─────────────
+    // Immediate hard delete (GDPR right-to-erasure).
+    // Requires the user to already be in 'deleted' status to prevent
+    // accidental single-click data loss.
+    scoped.post<{ Params: { userId: string } }>('/:userId/purge', {
+      preHandler: adminAuth,
+      config: { rateLimit: { max: 10, timeWindow: '1 minute' } },
+    }, async (request, reply) => {
+      const { userId } = request.params;
+
+      const [current] = await db
+        .select({ id: schema.appUsers.id, status: schema.appUsers.status })
+        .from(schema.appUsers)
+        .where(eq(schema.appUsers.id, userId))
+        .limit(1);
+
+      if (!current) return reply.status(404).send({ error: 'User not found' });
+      if (current.status !== 'deleted') {
+        return reply.status(409).send({
+          error: 'User must be soft-deleted before purge. Call DELETE first.',
+        });
+      }
+
+      await db.delete(schema.appUsers).where(eq(schema.appUsers.id, userId));
+      return reply.send({ ok: true });
+    });
+  });
+}
+
+// 16-char password from an unambiguous alphabet (no 0/O/1/l/I).
+function generateTempPassword(length: number): string {
+  const alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnpqrstuvwxyz23456789';
+  const bytes = crypto.randomBytes(length);
+  let out = '';
+  for (let i = 0; i < length; i++) {
+    out += alphabet[bytes[i] % alphabet.length];
+  }
+  return out;
+}

--- a/apps/api/src/routes/admin/app-users.ts
+++ b/apps/api/src/routes/admin/app-users.ts
@@ -413,13 +413,22 @@ export async function appUserAdminRoutes(app: FastifyInstance) {
   });
 }
 
-// 16-char password from an unambiguous alphabet (no 0/O/1/l/I).
+// Temp password from an unambiguous alphabet (no 0/O/1/l/I).
+// Uses rejection sampling: any random byte outside the largest
+// multiple of `alphabet.length` below 256 is discarded, so every
+// character has exactly equal probability. With a 56-char alphabet
+// the cutoff is 224 and the expected reject rate is (256-224)/256 ≈ 12.5%.
 function generateTempPassword(length: number): string {
   const alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnpqrstuvwxyz23456789';
-  const bytes = crypto.randomBytes(length);
+  const cutoff = 256 - (256 % alphabet.length);
   let out = '';
-  for (let i = 0; i < length; i++) {
-    out += alphabet[bytes[i] % alphabet.length];
+  while (out.length < length) {
+    const buf = crypto.randomBytes(length - out.length);
+    for (let i = 0; i < buf.length; i++) {
+      if (buf[i] < cutoff) {
+        out += alphabet[buf[i] % alphabet.length];
+      }
+    }
   }
   return out;
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,3 +3,4 @@ export * from './types/prayer.js';
 export * from './types/multi-room.js';
 export * from './types/holidays.js';
 export * from './types/analytics.js';
+export * from './types/user.js';

--- a/packages/shared/src/types/user.ts
+++ b/packages/shared/src/types/user.ts
@@ -1,0 +1,75 @@
+// ─────────────────────────────────────────────────────────────
+// App User — mobile/PWA end users (separate from admin users)
+// ─────────────────────────────────────────────────────────────
+
+export type AppUserStatus = 'active' | 'invited' | 'blocked' | 'deleted';
+
+export type AppUserAuthProvider = 'google' | 'email';
+
+export interface AppUser {
+  id: string;
+  email: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  language: string;
+  status: AppUserStatus;
+  emailVerified: boolean;
+  authProviders: AppUserAuthProvider[];
+  mustChangePassword: boolean;
+  lastLoginAt: string | null;
+  blockedAt: string | null;
+  blockedReason: string | null;
+  deletedAt: string | null;
+  purgeAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// Fields the user can update on their own profile
+export interface AppUserProfileUpdate {
+  displayName?: string;
+  avatarUrl?: string;
+  language?: string;
+}
+
+// Fields an admin provides when creating a user directly
+export interface AdminAppUserCreate {
+  email: string;
+  displayName: string;
+  tempPassword: string;
+  language?: string;
+}
+
+// Fields an admin can edit on an existing user
+export interface AdminAppUserUpdate {
+  email?: string;
+  displayName?: string;
+  language?: string;
+}
+
+export interface AdminAppUserBlockRequest {
+  reason: string;
+}
+
+// Admin list endpoint query params
+export interface AdminAppUserListQuery {
+  page?: number;
+  limit?: number;
+  search?: string;
+  status?: AppUserStatus;
+  authProvider?: AppUserAuthProvider;
+}
+
+export interface AdminAppUserListResponse {
+  users: AppUser[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+// Response shape when admin creates a user or resets a password —
+// the temp password is shown ONCE and never stored in plaintext again.
+export interface AdminAppUserCredentialResponse {
+  user: AppUser;
+  tempPassword: string;
+}


### PR DESCRIPTION
## Summary

Lays the foundation for managing mobile/PWA app users from the admin panel. This is **stages 1–2 of a larger plan** ([see plan file][plan]) — backend schema, shared types, and admin CRUD endpoints. No UI yet; user-facing self-service endpoints and the purge worker come in follow-up PRs.

- **Schema**: extend `app_users` with lifecycle fields (status, blocked/deleted/purge timestamps, must-change-password, created-by); add `devices.app_user_id` FK for user-device linking
- **Migration fix**: `migrate.ts` was never creating `app_users` or `sso_config` tables (latent bug that would break fresh installs). Fixed, plus idempotent `ALTER … ADD COLUMN IF NOT EXISTS` block for upgrades
- **Shared types** in `@myathan/shared`: `AppUser`, `AppUserStatus`, admin CRUD request/response shapes
- **Admin API** at `/api/admin/app-users`: list (with search + status/provider filters), detail (with linked devices), create, patch, block, unblock, reset-password, soft-delete, restore, purge

## Key design decisions

- **Google + email/password** both supported (not Google-only)
- **Soft delete with 30-day grace period**, then hard purge via dedicated endpoint (next PR: scheduled worker)
- **Direct admin create** with temp password returned exactly once — forces `mustChangePassword=true` so the user has to rotate it on first login
- **Purge guardrail**: hard delete requires the user to already be in `status='deleted'`, preventing accidental one-click data loss
- **No PII leakage**: `toAppUser()` serializer drops `password_hash` and replaces raw `google_id` with a boolean `authProviders: ['google','email']` array

## Security

- All admin routes behind `adminAuth` preHandler + scoped `@fastify/rate-limit`
- Temp passwords generated via `crypto.randomBytes` over an unambiguous alphabet (no 0/O/1/l/I)
- Email-change path checks for uniqueness against other users

## Out of scope (follow-up PRs)

- [ ] Session invalidation on block — needs status check in `app-auth.ts` middleware
- [ ] User-facing `/api/auth/profile`, `/api/auth/change-password`, `/api/auth/devices`, `/api/auth/account`
- [ ] Purge worker (scheduled job that deletes rows where `purge_at <= NOW()`)
- [ ] Admin panel UI (`apps/admin/src/pages/AppUsers.tsx` + detail + create modal)
- [ ] Mobile/web app auth UI (Login, Register, Profile, force-change-password)

## Test plan

- [ ] `npm install` + `npm run build --workspace=apps/api` typechecks clean
- [ ] Fresh DB: `migrateDatabase()` creates `app_users` and `sso_config` tables
- [ ] Existing DB: migration ALTERs add new columns without errors
- [ ] `POST /api/admin/app-users` with valid body returns 201 + temp password in response body
- [ ] `POST /api/admin/app-users` with duplicate email returns 409
- [ ] `GET /api/admin/app-users?search=foo&status=active&authProvider=google` filters correctly
- [ ] `GET /api/admin/app-users/:id` response has no `passwordHash` or raw `googleId` field
- [ ] `POST /:id/block` sets status and `blockedAt`; `POST /:id/unblock` clears them
- [ ] `DELETE /:id` sets `purgeAt` ~30d out; `POST /:id/restore` reverses it
- [ ] `POST /:id/purge` on a non-deleted user returns 409
- [ ] `POST /:id/purge` on a soft-deleted user removes the row
- [ ] All endpoints reject requests without a valid `admin_session` cookie (401)

[plan]: https://github.com/anthropics/claude-code — plan file lives locally at `~/.claude/plans/curried-baking-crab.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)