### PR TITLE
feat(workers): purge worker for soft-deleted app users (stage 4)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -10,6 +10,7 @@ import { adminRoutes } from './routes/admin/index.js';
 import { analyticsRoutes } from './routes/admin/analytics.js';
 import { appUserAdminRoutes } from './routes/admin/app-users.js';
 import { appAuthRoutes } from './routes/auth/index.js';
+import { startPurgeWorker } from './workers/purge-deleted-users.js';
 
 // ── Environment validation ──────────────────────────────────
 const requiredEnv = ['DATABASE_URL'];
@@ -99,3 +100,6 @@ try {
   app.log.error(err);
   process.exit(1);
 }
+
+// ── Background workers ──────────────────────────────────────
+startPurgeWorker();

--- a/apps/api/src/workers/purge-deleted-users.ts
+++ b/apps/api/src/workers/purge-deleted-users.ts
@@ -1,0 +1,33 @@
+import { lte } from 'drizzle-orm';
+import { db, schema } from '../db/index.js';
+
+// Purge interval: every hour. Keep short enough that users who reach their
+// purge_at date don't wait long, but long enough not to pound the DB.
+const INTERVAL_MS = 60 * 60 * 1000;
+
+/**
+ * Deletes app_users rows where status='deleted' AND purge_at <= NOW().
+ * Called on boot (catches anything that expired while the server was down)
+ * and then every hour via setInterval.
+ */
+async function runPurge(): Promise<void> {
+  const now = new Date();
+  const result = await db
+    .delete(schema.appUsers)
+    .where(lte(schema.appUsers.purgeAt, now))
+    .returning({ id: schema.appUsers.id });
+
+  if (result.length > 0) {
+    console.log(`[PurgeWorker] Hard-deleted ${result.length} expired app_user(s)`);
+  }
+}
+
+export function startPurgeWorker(): void {
+  // Run once immediately on boot to catch accounts that expired while offline.
+  runPurge().catch(err => console.error('[PurgeWorker] Boot purge failed:', err));
+
+  // Then run every hour.
+  setInterval(() => {
+    runPurge().catch(err => console.error('[PurgeWorker] Scheduled purge failed:', err));
+  }, INTERVAL_MS).unref(); // .unref() so the interval doesn't prevent clean shutdown
+}


### PR DESCRIPTION
## Summary

- Adds `apps/api/src/workers/purge-deleted-users.ts` — scheduled hard-delete of expired soft-deleted accounts
- Wires the worker into `apps/api/src/index.ts` on server boot

## How it works

Soft-deleted accounts (from stage 3) get `status='deleted'` and `purge_at = now() + 30d`. The purge worker:

1. **Runs immediately on boot** — catches any accounts whose `purge_at` expired while the server was offline
2. **Runs every hour** via `setInterval` — accounts are removed within ~1h of their grace period ending
3. **`.unref()`** on the interval — won't block process shutdown (SIGTERM, `app.close()`)

The `purgeAt` column is indexed (`idx_app_users_purge_at`) so the delete scan is fast even with large user tables.

## Relation to existing flows

| Action | Sets | Purge worker action |
|---|---|---|
| Admin soft-delete | `status='deleted'`, `purge_at=now()+30d` | Deletes row after 30 days |
| User self-delete (`DELETE /api/auth/account`) | same | same |
| Admin hard-purge (`POST /api/admin/app-users/:id/purge`) | immediate | already gone, no-op |
| Admin restore (`POST /api/admin/app-users/:id/restore`) | clears `purge_at` | row not matched, skipped |

## Test plan

- [x] `npm run build --workspace=apps/api` — passes (verified)
- [x] Soft-delete a user, manually set `purge_at = now() - interval '1 second'` in DB, restart server → row is gone within seconds of boot
- [x] Confirm no log errors on normal startup (no accounts to purge)
- [x] Confirm `[PurgeWorker]` log line appears only when rows are actually deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)