### PR TITLE
feat(web): auth infrastructure — AuthContext, Login, Register, PrivateRoute (stage 6)

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,3 @@
+# Google OAuth Client ID (get from Google Cloud Console)
+# Leave empty to disable Google sign-in (email/password only)
+VITE_GOOGLE_CLIENT_ID=

--- a/apps/web/src/components/PrivateRoute.tsx
+++ b/apps/web/src/components/PrivateRoute.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+export function PrivateRoute({ children }: { children: React.ReactNode }) {
+  const { user, loading } = useAuth();
+  const location = useLocation();
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-center">
+          <div className="w-10 h-10 border-4 border-gray-200 border-t-emerald-700 rounded-full animate-spin mx-auto mb-3" />
+          <p className="text-gray-400 text-sm">Loading…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  // Redirect to force-change-password before anything else
+  if (user.mustChangePassword && location.pathname !== '/change-password') {
+    return <Navigate to="/change-password" replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/apps/web/src/context/AuthContext.tsx
+++ b/apps/web/src/context/AuthContext.tsx
@@ -1,0 +1,59 @@
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import type { AppUser } from '@myathan/shared';
+import { authApi } from '../lib/auth-api';
+
+interface AuthContextValue {
+  user: AppUser | null;
+  loading: boolean;
+  signIn: (token: string, user: AppUser) => void;
+  signOut: () => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<AppUser | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const signIn = useCallback((token: string, newUser: AppUser) => {
+    authApi.saveToken(token);
+    setUser(newUser);
+  }, []);
+
+  const signOut = useCallback(async () => {
+    await authApi.logout().catch(() => {});
+    authApi.clearToken();
+    setUser(null);
+  }, []);
+
+  const refresh = useCallback(async () => {
+    try {
+      const { user: me } = await authApi.me();
+      setUser(me);
+    } catch {
+      authApi.clearToken();
+      setUser(null);
+    }
+  }, []);
+
+  // On mount: try to restore session from stored token / cookie
+  useEffect(() => {
+    authApi.me()
+      .then(({ user: me }) => setUser(me))
+      .catch(() => { authApi.clearToken(); setUser(null); })
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, loading, signIn, signOut, refresh }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used inside <AuthProvider>');
+  return ctx;
+}

--- a/apps/web/src/lib/auth-api.ts
+++ b/apps/web/src/lib/auth-api.ts
@@ -1,0 +1,82 @@
+import type { AppUser } from '@myathan/shared';
+
+const BASE = '';
+
+// Token stored in memory + localStorage for persistence across reloads.
+// The API also sets an httpOnly app_session cookie, but we carry the token
+// in Authorization headers too so BLE-provisioned sessions (same-origin) work.
+const TOKEN_KEY = 'app_token';
+
+export function getToken(): string | null {
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+function setToken(token: string) {
+  localStorage.setItem(TOKEN_KEY, token);
+}
+
+export function clearToken() {
+  localStorage.removeItem(TOKEN_KEY);
+}
+
+async function request<T>(method: string, path: string, body?: unknown): Promise<T> {
+  const headers: Record<string, string> = {};
+  if (body) headers['Content-Type'] = 'application/json';
+  const token = getToken();
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    credentials: 'include',
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: res.statusText }));
+    const e = new Error(err.error || `${res.status} ${res.statusText}`) as any;
+    e.status = res.status;
+    e.code = err.code;
+    throw e;
+  }
+  return res.json();
+}
+
+export const authApi = {
+  register: (email: string, password: string, displayName?: string) =>
+    request<{ user: AppUser; token: string }>('POST', '/api/auth/register', { email, password, displayName }),
+
+  login: (email: string, password: string) =>
+    request<{ user: AppUser; token: string }>('POST', '/api/auth/login', { email, password }),
+
+  googleAuth: (idToken: string) =>
+    request<{ user: AppUser; token: string }>('POST', '/api/auth/google', { idToken }),
+
+  me: () =>
+    request<{ user: AppUser }>('GET', '/api/auth/me'),
+
+  logout: () =>
+    request<{ ok: boolean }>('POST', '/api/auth/logout'),
+
+  updateProfile: (data: { displayName?: string; avatarUrl?: string; language?: string }) =>
+    request<{ user: AppUser }>('PATCH', '/api/auth/profile', data),
+
+  changePassword: (newPassword: string, currentPassword?: string) =>
+    request<{ user: AppUser }>('POST', '/api/auth/change-password', { newPassword, currentPassword }),
+
+  getDevices: () =>
+    request<{ devices: any[] }>('GET', '/api/auth/devices'),
+
+  unlinkDevice: (deviceId: string) =>
+    request<{ ok: boolean }>('POST', `/api/auth/devices/${encodeURIComponent(deviceId)}/unlink`),
+
+  deleteAccount: () =>
+    request<{ ok: boolean; purgeAt: string }>('DELETE', '/api/auth/account'),
+
+  getProviders: () =>
+    request<{ providers: Record<string, boolean> }>('GET', '/api/auth/providers'),
+
+  // Helpers — called by AuthContext after a successful auth response
+  saveToken: setToken,
+  clearToken,
+};

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { ErrorBoundary } from './components/ErrorBoundary';
+import { AuthProvider } from './context/AuthContext';
+import { PrivateRoute } from './components/PrivateRoute';
 import { Layout } from './components/Layout';
 import { Home } from './pages/Home';
 import { Setup } from './pages/Setup';
@@ -10,22 +12,61 @@ import { AudioSettings } from './pages/AudioSettings';
 import { RamadanSettings } from './pages/RamadanSettings';
 import { MultiRoom } from './pages/MultiRoom';
 import { DeviceSettings } from './pages/DeviceSettings';
+import { Login } from './pages/Login';
+import { Register } from './pages/Register';
+import { ForceChangePassword } from './pages/ForceChangePassword';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ErrorBoundary>
       <BrowserRouter>
-        <Layout>
+        <AuthProvider>
           <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/setup" element={<Setup />} />
-            <Route path="/prayers" element={<PrayerTimes />} />
-            <Route path="/audio" element={<AudioSettings />} />
-            <Route path="/ramadan" element={<RamadanSettings />} />
-            <Route path="/multi-room" element={<MultiRoom />} />
-            <Route path="/settings" element={<DeviceSettings />} />
+            {/* Public routes — no Layout wrapper */}
+            <Route path="/login" element={<Login />} />
+            <Route path="/register" element={<Register />} />
+            <Route path="/change-password" element={
+              <PrivateRoute><ForceChangePassword /></PrivateRoute>
+            } />
+
+            {/* Protected routes — inside Layout */}
+            <Route path="/" element={
+              <PrivateRoute>
+                <Layout><Home /></Layout>
+              </PrivateRoute>
+            } />
+            <Route path="/setup" element={
+              <PrivateRoute>
+                <Layout><Setup /></Layout>
+              </PrivateRoute>
+            } />
+            <Route path="/prayers" element={
+              <PrivateRoute>
+                <Layout><PrayerTimes /></Layout>
+              </PrivateRoute>
+            } />
+            <Route path="/audio" element={
+              <PrivateRoute>
+                <Layout><AudioSettings /></Layout>
+              </PrivateRoute>
+            } />
+            <Route path="/ramadan" element={
+              <PrivateRoute>
+                <Layout><RamadanSettings /></Layout>
+              </PrivateRoute>
+            } />
+            <Route path="/multi-room" element={
+              <PrivateRoute>
+                <Layout><MultiRoom /></Layout>
+              </PrivateRoute>
+            } />
+            <Route path="/settings" element={
+              <PrivateRoute>
+                <Layout><DeviceSettings /></Layout>
+              </PrivateRoute>
+            } />
           </Routes>
-        </Layout>
+        </AuthProvider>
       </BrowserRouter>
     </ErrorBoundary>
   </React.StrictMode>,

--- a/apps/web/src/pages/ForceChangePassword.tsx
+++ b/apps/web/src/pages/ForceChangePassword.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import { authApi } from '../lib/auth-api';
+
+export function ForceChangePassword() {
+  const { refresh } = useAuth();
+  const navigate = useNavigate();
+  const [newPassword, setNewPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    if (newPassword !== confirm) {
+      setError('Passwords do not match');
+      return;
+    }
+    if (newPassword.length < 8) {
+      setError('Password must be at least 8 characters');
+      return;
+    }
+    setLoading(true);
+    try {
+      // mustChangePassword=true → no currentPassword required
+      await authApi.changePassword(newPassword);
+      await refresh(); // clears mustChangePassword from context
+      navigate('/', { replace: true });
+    } catch (err: any) {
+      setError(err.message || 'Failed to update password');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        <div className="text-center mb-8">
+          <div className="w-16 h-16 bg-amber-500 rounded-2xl flex items-center justify-center mx-auto mb-3 shadow-lg">
+            <span className="text-white text-2xl">🔒</span>
+          </div>
+          <h1 className="text-xl font-bold text-gray-900">Set your password</h1>
+          <p className="text-gray-500 text-sm mt-1">
+            Your account requires a new password before you can continue.
+          </p>
+        </div>
+
+        {error && (
+          <div className="bg-red-50 border border-red-200 text-red-700 rounded-xl px-4 py-3 text-sm mb-4">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <input
+            type="password"
+            required
+            minLength={8}
+            value={newPassword}
+            onChange={e => setNewPassword(e.target.value)}
+            placeholder="New password (min 8 characters)"
+            autoComplete="new-password"
+            className="w-full border border-gray-200 rounded-xl px-4 py-3 text-sm outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500"
+          />
+          <input
+            type="password"
+            required
+            value={confirm}
+            onChange={e => setConfirm(e.target.value)}
+            placeholder="Confirm new password"
+            autoComplete="new-password"
+            className="w-full border border-gray-200 rounded-xl px-4 py-3 text-sm outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500"
+          />
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full bg-emerald-700 text-white py-3 rounded-xl font-semibold text-sm disabled:opacity-50"
+          >
+            {loading ? 'Saving…' : 'Set password & continue'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -1,0 +1,158 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate, useLocation, Link } from 'react-router-dom';
+import { GoogleLogin, GoogleOAuthProvider } from '@react-oauth/google';
+import { useAuth } from '../context/AuthContext';
+import { authApi } from '../lib/auth-api';
+
+const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID ?? '';
+
+export function Login() {
+  const { user, signIn } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const from = (location.state as any)?.from?.pathname ?? '/';
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [providers, setProviders] = useState<Record<string, boolean>>({ email: true, google: false });
+
+  // Already logged in → redirect
+  useEffect(() => {
+    if (user) navigate(from, { replace: true });
+  }, [user]);
+
+  useEffect(() => {
+    authApi.getProviders()
+      .then(r => setProviders(r.providers))
+      .catch(() => {});
+  }, []);
+
+  async function handleEmailLogin(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+    try {
+      const res = await authApi.login(email, password);
+      signIn(res.token, res.user);
+      navigate(res.user.mustChangePassword ? '/change-password' : from, { replace: true });
+    } catch (err: any) {
+      if (err.code === 'account_blocked') {
+        setError('Your account has been blocked. Contact support.');
+      } else if (err.code === 'account_deleted') {
+        setError('This account has been deleted.');
+      } else {
+        setError(err.message || 'Invalid email or password');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleGoogle(credentialResponse: { credential?: string }) {
+    if (!credentialResponse.credential) return;
+    setError('');
+    setLoading(true);
+    try {
+      const res = await authApi.googleAuth(credentialResponse.credential);
+      signIn(res.token, res.user);
+      navigate(res.user.mustChangePassword ? '/change-password' : from, { replace: true });
+    } catch (err: any) {
+      if (err.code === 'account_blocked') {
+        setError('Your account has been blocked. Contact support.');
+      } else {
+        setError(err.message || 'Google sign-in failed');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        {/* Logo */}
+        <div className="text-center mb-8">
+          <div className="w-16 h-16 bg-emerald-700 rounded-2xl flex items-center justify-center mx-auto mb-3 shadow-lg">
+            <span className="text-white text-2xl font-bold">M</span>
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900">MyAthan</h1>
+          <p className="text-gray-500 text-sm mt-1">Sign in to manage your device</p>
+        </div>
+
+        {error && (
+          <div className="bg-red-50 border border-red-200 text-red-700 rounded-xl px-4 py-3 text-sm mb-4">
+            {error}
+          </div>
+        )}
+
+        {/* Google sign-in */}
+        {providers.google && GOOGLE_CLIENT_ID && (
+          <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID}>
+            <div className="mb-4">
+              <GoogleLogin
+                onSuccess={handleGoogle}
+                onError={() => setError('Google sign-in failed')}
+                width="100%"
+                text="signin_with"
+                shape="rectangular"
+                theme="outline"
+              />
+            </div>
+          </GoogleOAuthProvider>
+        )}
+
+        {/* Divider — shown only when both providers available */}
+        {providers.google && providers.email && GOOGLE_CLIENT_ID && (
+          <div className="flex items-center gap-3 mb-4">
+            <div className="flex-1 h-px bg-gray-200" />
+            <span className="text-gray-400 text-xs">or</span>
+            <div className="flex-1 h-px bg-gray-200" />
+          </div>
+        )}
+
+        {/* Email/password form */}
+        {providers.email && (
+          <form onSubmit={handleEmailLogin} className="space-y-3">
+            <input
+              type="email"
+              required
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              placeholder="Email address"
+              autoComplete="email"
+              className="w-full border border-gray-200 rounded-xl px-4 py-3 text-sm outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500"
+            />
+            <input
+              type="password"
+              required
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              placeholder="Password"
+              autoComplete="current-password"
+              className="w-full border border-gray-200 rounded-xl px-4 py-3 text-sm outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500"
+            />
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full bg-emerald-700 text-white py-3 rounded-xl font-semibold text-sm disabled:opacity-50"
+            >
+              {loading ? 'Signing in…' : 'Sign in'}
+            </button>
+          </form>
+        )}
+
+        {/* Register link */}
+        {providers.email && (
+          <p className="text-center text-sm text-gray-500 mt-6">
+            Don't have an account?{' '}
+            <Link to="/register" className="text-emerald-700 font-medium">
+              Create one
+            </Link>
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/Register.tsx
+++ b/apps/web/src/pages/Register.tsx
@@ -1,0 +1,138 @@
+import React, { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { GoogleLogin, GoogleOAuthProvider } from '@react-oauth/google';
+import { useAuth } from '../context/AuthContext';
+import { authApi } from '../lib/auth-api';
+
+const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID ?? '';
+
+export function Register() {
+  const { signIn } = useAuth();
+  const navigate = useNavigate();
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  async function handleRegister(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+    try {
+      const res = await authApi.register(email, password, displayName || undefined);
+      signIn(res.token, res.user);
+      navigate('/', { replace: true });
+    } catch (err: any) {
+      setError(err.message || 'Registration failed');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleGoogle(credentialResponse: { credential?: string }) {
+    if (!credentialResponse.credential) return;
+    setError('');
+    setLoading(true);
+    try {
+      const res = await authApi.googleAuth(credentialResponse.credential);
+      signIn(res.token, res.user);
+      navigate('/', { replace: true });
+    } catch (err: any) {
+      setError(err.message || 'Google sign-in failed');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        {/* Logo */}
+        <div className="text-center mb-8">
+          <div className="w-16 h-16 bg-emerald-700 rounded-2xl flex items-center justify-center mx-auto mb-3 shadow-lg">
+            <span className="text-white text-2xl font-bold">M</span>
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900">Create account</h1>
+          <p className="text-gray-500 text-sm mt-1">Get started with MyAthan</p>
+        </div>
+
+        {error && (
+          <div className="bg-red-50 border border-red-200 text-red-700 rounded-xl px-4 py-3 text-sm mb-4">
+            {error}
+          </div>
+        )}
+
+        {/* Google */}
+        {GOOGLE_CLIENT_ID && (
+          <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID}>
+            <div className="mb-4">
+              <GoogleLogin
+                onSuccess={handleGoogle}
+                onError={() => setError('Google sign-in failed')}
+                width="100%"
+                text="signup_with"
+                shape="rectangular"
+                theme="outline"
+              />
+            </div>
+          </GoogleOAuthProvider>
+        )}
+
+        {GOOGLE_CLIENT_ID && (
+          <div className="flex items-center gap-3 mb-4">
+            <div className="flex-1 h-px bg-gray-200" />
+            <span className="text-gray-400 text-xs">or</span>
+            <div className="flex-1 h-px bg-gray-200" />
+          </div>
+        )}
+
+        {/* Email form */}
+        <form onSubmit={handleRegister} className="space-y-3">
+          <input
+            type="text"
+            value={displayName}
+            onChange={e => setDisplayName(e.target.value)}
+            placeholder="Display name (optional)"
+            autoComplete="name"
+            className="w-full border border-gray-200 rounded-xl px-4 py-3 text-sm outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500"
+          />
+          <input
+            type="email"
+            required
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            placeholder="Email address"
+            autoComplete="email"
+            className="w-full border border-gray-200 rounded-xl px-4 py-3 text-sm outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500"
+          />
+          <input
+            type="password"
+            required
+            minLength={8}
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            placeholder="Password (min 8 characters)"
+            autoComplete="new-password"
+            className="w-full border border-gray-200 rounded-xl px-4 py-3 text-sm outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500"
+          />
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full bg-emerald-700 text-white py-3 rounded-xl font-semibold text-sm disabled:opacity-50"
+          >
+            {loading ? 'Creating account…' : 'Create account'}
+          </button>
+        </form>
+
+        <p className="text-center text-sm text-gray-500 mt-6">
+          Already have an account?{' '}
+          <Link to="/login" className="text-emerald-700 font-medium">
+            Sign in
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -5,5 +5,11 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+    },
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -579,6 +579,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@myathan/shared": "*",
+        "@react-oauth/google": "^0.13.5",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.0.0"
@@ -2017,6 +2018,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2340,6 +2342,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2383,6 +2386,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2465,7 +2469,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2483,7 +2486,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2501,7 +2503,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2519,7 +2520,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2537,7 +2537,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2555,7 +2554,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2573,7 +2571,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2591,7 +2588,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2609,7 +2605,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2627,7 +2622,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2645,7 +2639,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2663,7 +2656,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2681,7 +2673,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2699,7 +2690,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2717,7 +2707,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2735,7 +2724,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2753,7 +2741,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2788,7 +2775,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2823,7 +2809,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2858,7 +2843,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2876,7 +2860,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2894,7 +2877,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2912,7 +2894,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3204,7 +3185,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
@@ -3492,6 +3472,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@react-oauth/google": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.13.5.tgz",
+      "integrity": "sha512-xQWri2s/3nNekZJ4uuov2aAfQYu83bN3864KcFqw2pK1nNbFurQIjPFDXhWaKH3IjYJ2r/9yyIIpsn5lMqrheQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -4659,6 +4649,7 @@
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4675,6 +4666,7 @@
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -4692,6 +4684,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4886,7 +4879,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5101,6 +5093,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5221,8 +5214,7 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/component-emitter": {
       "version": "1.3.1",
@@ -5650,7 +5642,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5668,7 +5659,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5686,7 +5676,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6616,6 +6605,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -6776,6 +6766,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6891,6 +6882,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6900,6 +6892,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7440,27 +7433,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/terser": {
-      "version": "5.46.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
-      "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.15.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/thread-stream": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
@@ -7538,6 +7510,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -7565,7 +7538,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7583,7 +7555,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7601,7 +7572,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7619,7 +7589,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7637,7 +7606,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7655,7 +7623,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7673,7 +7640,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7691,7 +7657,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7709,7 +7674,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7727,7 +7691,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7745,7 +7708,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7763,7 +7725,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7781,7 +7742,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7799,7 +7759,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7817,7 +7776,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7835,7 +7793,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7853,7 +7810,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7871,7 +7827,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7889,7 +7844,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7907,7 +7861,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7925,7 +7878,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7943,7 +7895,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7961,7 +7912,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8066,6 +8016,7 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -8264,24 +8215,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/zod": {
       "version": "3.25.76",


### PR DESCRIPTION
## Summary

Wires authentication into the web app (PWA). All existing device pages are now gated behind login. Google OAuth and email/password are both supported.

## New files

| File | Purpose |
|---|---|
| `src/lib/auth-api.ts` | Fetch client for all `/api/auth/*` endpoints; JWT stored in `localStorage`, sent as `Authorization: Bearer` header |
| `src/context/AuthContext.tsx` | `AuthProvider` + `useAuth()` hook; restores session on mount via `/api/auth/me` |
| `src/components/PrivateRoute.tsx` | Redirects unauthenticated → `/login`; redirects `mustChangePassword` → `/change-password` |
| `src/pages/Login.tsx` | Google OAuth button + email/password form; reads enabled providers from `/api/auth/providers` |
| `src/pages/Register.tsx` | Google OAuth + email/password registration |
| `src/pages/ForceChangePassword.tsx` | Required when `mustChangePassword=true`; blocks all navigation until complete |
| `apps/web/.env.example` | `VITE_GOOGLE_CLIENT_ID` placeholder |

## Changed files

| File | Change |
|---|---|
| `src/main.tsx` | Wraps `AuthProvider` around everything; all 7 device routes behind `PrivateRoute`; adds `/login`, `/register`, `/change-password` routes |
| `vite.config.ts` | Adds `/api` proxy to `localhost:3000` for local dev |

## Auth flow

```
User opens app
  → AuthContext fetches /api/auth/me on mount
  → 401 → redirect to /login
  
Login (email/password)
  → POST /api/auth/login → token + user
  → signIn(token, user) → localStorage + state
  → redirect to original destination

Login (Google)
  → @react-oauth/google → ID token
  → POST /api/auth/google → token + user
  → signIn() → redirect

mustChangePassword=true
  → PrivateRoute redirects to /change-password
  → POST /api/auth/change-password (no currentPassword needed)
  → refresh() clears flag → redirect to /
```

## Notes

- **Google Client ID**: set `VITE_GOOGLE_CLIENT_ID` in `.env.local`. If unset, Google button is hidden and email-only mode applies automatically.
- **IDE false positive**: `vite.config.ts` shows a TS error in VS Code because the root `node_modules/vite@6` is resolved instead of the workspace-local `vite@7`. Build (`tsc && vite build`) passes cleanly — 60 modules, 0 errors.

## Build

`tsc && vite build` — 60 modules, 0 errors, 269KB bundle ✅

## Test plan

- [ ] Fresh incognito → any route redirects to `/login`
- [ ] Login with email/password → lands on `/`
- [ ] Login with wrong password → error message shown
- [ ] Blocked account → `Account has been blocked` error
- [ ] Google sign-in completes (requires `VITE_GOOGLE_CLIENT_ID` set)
- [ ] Register with email → lands on `/`
- [ ] Admin-created user (mustChangePassword=true) → forced to `/change-password` after login
- [ ] Force-change completes → lands on `/`, `mustChangePassword` cleared
- [ ] Logout (via profile page — Stage 7) clears token + redirects to `/login`
- [ ] Token persists across page reload (localStorage)
- [ ] `/api` proxy routes correctly to backend in dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)