### PR TITLE
feat: device-user linking — link endpoint + BLE auto-link on setup (stage 9)

### DIFF
--- a/apps/api/src/routes/auth/index.ts
+++ b/apps/api/src/routes/auth/index.ts
@@ -353,6 +353,42 @@ export async function appAuthRoutes(app: FastifyInstance) {
       return reply.send({ devices });
     });
 
+    // ── POST /api/auth/devices/:deviceId/link ────────────────
+    // Link a device to the authenticated user's account.
+    // The device must already exist in the DB (registered by the firmware).
+    // A device already linked to a different user is rejected (403).
+    // Linking to oneself is idempotent (200).
+    scoped.post<{ Params: { deviceId: string } }>('/devices/:deviceId/link', {
+      config: { rateLimit: { max: 20, timeWindow: '1 minute' } },
+      preHandler: appAuth,
+    }, async (request, reply) => {
+      const { id } = (request as any).appUser as { id: string };
+      const { deviceId } = request.params;
+
+      const [device] = await db.select({
+        id: schema.devices.id,
+        appUserId: schema.devices.appUserId,
+      }).from(schema.devices)
+        .where(eq(schema.devices.deviceId, deviceId))
+        .limit(1);
+
+      if (!device) return reply.status(404).send({ error: 'Device not found' });
+
+      if (device.appUserId && device.appUserId !== id) {
+        return reply.status(403).send({ error: 'Device is linked to another account' });
+      }
+
+      if (device.appUserId === id) {
+        return reply.send({ ok: true }); // idempotent
+      }
+
+      await db.update(schema.devices)
+        .set({ appUserId: id, updatedAt: new Date() })
+        .where(eq(schema.devices.id, device.id));
+
+      return reply.send({ ok: true });
+    });
+
     // ── POST /api/auth/devices/:deviceId/unlink ───────────────
     // Detach a device the user owns (e.g. giving it to someone else).
     // Only the owner can unlink — admins use the admin route.

--- a/apps/web/src/lib/auth-api.ts
+++ b/apps/web/src/lib/auth-api.ts
@@ -67,6 +67,9 @@ export const authApi = {
   getDevices: () =>
     request<{ devices: any[] }>('GET', '/api/auth/devices'),
 
+  linkDevice: (deviceId: string) =>
+    request<{ ok: boolean }>('POST', `/api/auth/devices/${encodeURIComponent(deviceId)}/link`),
+
   unlinkDevice: (deviceId: string) =>
     request<{ ok: boolean }>('POST', `/api/auth/devices/${encodeURIComponent(deviceId)}/unlink`),
 

--- a/apps/web/src/lib/ble-provisioning.ts
+++ b/apps/web/src/lib/ble-provisioning.ts
@@ -33,6 +33,12 @@ export class BleProvisioner {
     return this.device;
   }
 
+  /** Returns the device ID as stored in the backend (lowercase of BLE name, e.g. "myathan-abcdef"). */
+  getDeviceId(): string | null {
+    if (!this.device?.name) return null;
+    return this.device.name.toLowerCase();
+  }
+
   async connect(): Promise<void> {
     if (!this.device) throw new Error('No device selected');
     this.server = await withTimeout(

--- a/apps/web/src/pages/Setup.tsx
+++ b/apps/web/src/pages/Setup.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { bleProvisioner } from '../lib/ble-provisioning';
+import { authApi } from '../lib/auth-api';
 
 type SetupStep = 'scan' | 'connect' | 'wifi' | 'sending' | 'done' | 'error';
 
@@ -9,6 +10,7 @@ export function Setup() {
   const [ssid, setSsid] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
+  const [linked, setLinked] = useState(false);
 
   async function handleScan() {
     try {
@@ -30,6 +32,20 @@ export function Setup() {
     try {
       setStep('sending');
       await bleProvisioner.sendCredentials(ssid, password);
+
+      // Link device to the logged-in user's account.
+      // Best-effort: device may not be in DB yet if it hasn't phoned home,
+      // but we try immediately and silently skip if not found.
+      const deviceId = bleProvisioner.getDeviceId();
+      if (deviceId) {
+        try {
+          await authApi.linkDevice(deviceId);
+          setLinked(true);
+        } catch {
+          // Non-fatal — user can link manually from Profile > Linked devices
+        }
+      }
+
       setStep('done');
     } catch (e: any) {
       setError(e.message || 'Failed to send credentials');
@@ -106,6 +122,14 @@ export function Setup() {
           <div className="text-4xl">✅</div>
           <p className="text-lg font-medium text-gray-900">Device Connected!</p>
           <p className="text-gray-500">Your MyAthan device is now connected to WiFi and will sync prayer times automatically.</p>
+          {linked && (
+            <p className="text-sm text-emerald-700 font-medium">Device linked to your account.</p>
+          )}
+          {!linked && (
+            <p className="text-xs text-gray-400">
+              Device not yet linked — visit Profile to link it once it comes online.
+            </p>
+          )}
           <a href="/" className="inline-block bg-emerald-700 text-white px-8 py-3 rounded-xl font-medium">
             Go to Home
           </a>


### PR DESCRIPTION
## Summary

- Adds `POST /api/auth/devices/:deviceId/link` — lets authenticated PWA users claim a device
- Wires auto-link into the BLE setup flow so the device is claimed immediately after WiFi provisioning
- Unlink already existed; Profile page already lists linked devices

## Changes

### Backend — `apps/api/src/routes/auth/index.ts`

**New endpoint: `POST /api/auth/devices/:deviceId/link`**

| Case | Response |
|---|---|
| Device not in DB | 404 |
| Device owned by another user | 403 |
| Already yours | 200 (idempotent) |
| Unlinked device | 200, sets `app_user_id = me.id` |

Protected by `appAuth` preHandler + rate limit (20/min).

### Web — `apps/web/src/lib/auth-api.ts`

Added `linkDevice(deviceId)` → `POST /api/auth/devices/:id/link`.

### Web — `apps/web/src/lib/ble-provisioning.ts`

Added `getDeviceId()` — returns `this.device.name.toLowerCase()` (e.g. `"myathan-abcdef"`), matching the backend `device_id` format.

### Web — `apps/web/src/pages/Setup.tsx`

After `sendCredentials()` succeeds, calls `authApi.linkDevice(deviceId)` silently:
- **Success** → shows "Device linked to your account" in the done step
- **Failure** (device not yet in DB — it hasn't sent its first heartbeat) → silently skipped, shows "link from Profile" hint instead. Non-fatal.

## Test plan

- [ ] Complete BLE setup flow → done screen shows "Device linked to your account"
- [ ] `GET /api/auth/devices` returns the newly linked device
- [ ] Link endpoint is idempotent — calling it twice returns 200 both times
- [ ] Link endpoint returns 403 when device belongs to a different user
- [ ] Link endpoint returns 404 for an unknown deviceId
- [ ] Unlink from Profile → device removed from `GET /api/auth/devices`
- [ ] Setup flow without device in DB (first boot, no heartbeat yet) → done screen shows "link from Profile" hint, no error thrown

🤖 Generated with [Claude Code](https://claude.com/claude-code)