### PR TITLE
fix(security): bump fast-jwt to 6.2.1 — ReDoS CVE fix

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,30 +14,31 @@
     "db:push": "drizzle-kit push"
   },
   "dependencies": {
-    "fastify": "^5.0.0",
+    "@aws-sdk/client-s3": "^3.650.0",
+    "@aws-sdk/s3-request-presigner": "^3.650.0",
     "@fastify/cookie": "^11.0.0",
     "@fastify/cors": "^10.0.0",
     "@fastify/helmet": "^12.0.0",
     "@fastify/jwt": "^10.0.0",
     "@fastify/multipart": "^9.0.0",
-    "drizzle-orm": "^0.45.2",
-    "pg": "^8.13.0",
-    "adhan": "^4.4.0",
-    "zod": "^3.23.0",
-    "@aws-sdk/client-s3": "^3.650.0",
-    "@aws-sdk/s3-request-presigner": "^3.650.0",
     "@fastify/rate-limit": "^10.0.0",
+    "@myathan/shared": "*",
+    "adhan": "^4.4.0",
     "bcryptjs": "^2.4.3",
-    "@myathan/shared": "*"
+    "drizzle-orm": "^0.45.2",
+    "fast-jwt": "^6.2.1",
+    "fastify": "^5.0.0",
+    "pg": "^8.13.0",
+    "zod": "^3.23.0"
   },
   "devDependencies": {
-    "typescript": "^5.5.0",
-    "tsx": "^4.19.0",
-    "vitest": "^4.1.3",
-    "drizzle-kit": "^0.31.10",
-    "@types/pg": "^8.11.0",
-    "@types/node": "^22.0.0",
     "@types/bcryptjs": "^2.4.0",
-    "supertest": "^7.0.0"
+    "@types/node": "^22.0.0",
+    "@types/pg": "^8.11.0",
+    "drizzle-kit": "^0.31.10",
+    "supertest": "^7.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.5.0",
+    "vitest": "^4.1.3"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@myathan/shared": "*",
+    "@react-oauth/google": "^0.13.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -559,6 +559,7 @@
         "adhan": "^4.4.0",
         "bcryptjs": "^2.4.3",
         "drizzle-orm": "^0.45.2",
+        "fast-jwt": "^6.2.1",
         "fastify": "^5.0.0",
         "pg": "^8.13.0",
         "zod": "^3.23.0"
@@ -3178,18 +3179,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
-      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -4872,20 +4861,6 @@
       "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
       "license": "MIT"
     },
-    "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/adhan": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/adhan/-/adhan-4.4.3.tgz",
@@ -5207,14 +5182,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/component-emitter": {
       "version": "1.3.1",
@@ -5749,15 +5716,16 @@
       }
     },
     "node_modules/fast-jwt": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/fast-jwt/-/fast-jwt-6.2.0.tgz",
-      "integrity": "sha512-8HzL09abkCBIaZZSOhDP8re1ozSWa6297so2u46IbeE4zznVEbYX/WrlnZP8K9GCr7gT5uT1uMvOSNZAY86DBQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/fast-jwt/-/fast-jwt-6.2.1.tgz",
+      "integrity": "sha512-tmXFiZpaFGm18TjhWE5bIQ6OoJGFifAQzW3g2H+HhHfmpvsjSswXt8i8RpI2u4EgyBugXiOTXvBMHXrs2hOg+w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@lukeed/ms": "^2.0.2",
         "asn1.js": "^5.4.1",
         "ecdsa-sig-formatter": "^1.0.11",
-        "mnemonist": "^0.40.0"
+        "mnemonist": "^0.40.0",
+        "safe-regex2": "^5.1.0"
       },
       "engines": {
         "node": ">=20"


### PR DESCRIPTION
## Summary

Fixes two medium-severity Dependabot alerts introduced when `@fastify/jwt@10.0.0` pulled in `fast-jwt@6.2.0`.

## Vulnerabilities fixed

| Alert | Severity | Description |
|---|---|---|
| Dependabot #11 | Medium | ReDoS via RegExp in `allowed*` fields → CPU exhaustion during token verification |
| Dependabot #12 | Medium | Stateful RegExp (`/g` or `/y`) causes non-deterministic claim validation (logical DoS) |

Both fixed in `fast-jwt@6.2.1` (released upstream).

## Change

- `apps/api/package.json` — added `"fast-jwt": "^6.2.1"` as a direct dependency to pin the patched version over the transitive `@fastify/jwt → fast-jwt@6.2.0` dep
- `package-lock.json` — updated accordingly; `npm audit` reports **0 vulnerabilities**
- `apps/web/package.json` — commits `@react-oauth/google` dep that was installed in Stage 6 but not reflected in the file

## Verification

```
npm ls fast-jwt
# fast-jwt@6.2.1 ✅

npm audit
# found 0 vulnerabilities ✅

npm run lint --workspace=apps/api
# 0 errors ✅

npm run build --workspace=apps/web
# 61 modules, 0 errors, 277KB ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)